### PR TITLE
Update Message.cs

### DIFF
--- a/src/Lithnet.Pan.RAProxy/PanApi/Message.cs
+++ b/src/Lithnet.Pan.RAProxy/PanApi/Message.cs
@@ -209,6 +209,7 @@ namespace Lithnet.Pan.RAProxy
 
             NameValueCollection queryString = HttpUtility.ParseQueryString(string.Empty);
 
+            /*\
             if (Config.ActiveEndPoint.UrlEncodeKey)
             {
                 queryString["key"] = HttpUtility.UrlEncode(ep.ApiKey);
@@ -217,6 +218,7 @@ namespace Lithnet.Pan.RAProxy
             {
                 queryString["key"] = ep.ApiKey;
             }
+			*/
 
             queryString["type"] = this.ApiType;
 
@@ -224,6 +226,17 @@ namespace Lithnet.Pan.RAProxy
 
             HttpWebRequest request = this.GetRequestContent(builder.Uri, messageText);
             request.ServicePoint.Expect100Continue = false;
+			
+
+            if (Config.ActiveEndPoint.UrlEncodeKey)
+            {
+                request.Headers["X-PAN-KEY"] = HttpUtility.UrlEncode(ep.ApiKey);
+            }
+            else
+            {
+                request.Headers["X-PAN-KEY"] = ep.ApiKey;
+            }
+
 
             using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
             {


### PR DESCRIPTION
Change API key from query to http header
due to a change in PAN OS 9.1
see https://docs.paloaltonetworks.com/pan-os/9-1/pan-os-release-notes/pan-os-9-1-release-information/changes-to-default-behavior.html